### PR TITLE
Fixed mixed security in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
     <meta name="author" content="HackCentral">
     <title>HackCentral.ca is Coming Soon</title>
     <link href="static/css/bootstrap.min.css" rel="stylesheet"/>
-    <link href='http://fonts.googleapis.com/css?family=Coustard' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Raleway:400,300' rel='stylesheet'
+    <link href='https://fonts.googleapis.com/css?family=Coustard' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Raleway:400,300' rel='stylesheet'
           type='text/css'>
     <link href="lib/font-awesome/css/font-awesome.min.css" rel="stylesheet"/>
     <link href="static/css/style.css" rel="stylesheet"/>


### PR DESCRIPTION
Two css files are being used unsecured on a secure webpage, causing chrome to not load the two css files.